### PR TITLE
Boostsrl Wiki and Dataset Bugfixes

### DIFF
--- a/.github/docs/advanced-boostsrl-template.md
+++ b/.github/docs/advanced-boostsrl-template.md
@@ -24,9 +24,11 @@ Provide some motivation for what is being solved, and how this helps to solve it
 
 Download: [NameOfDataset.zip](https://github.com/boost-starai/BoostSRL-Misc/blob/master/Datasets/.../....zip?raw=true) (*Size* KB)
 
-* `md5sum`: ...
+* `md5sum`: 
+  <p style="word-break: break-all;">stringoflettersandnumbers</p>
 
-* `sha256sum`: ...
+* `sha256sum`: 
+  <p style="word-break: break-all;">stringoflettersandnumbers</p>
 
 <button class="btn btn--primary btn--large" onclick="topOfPage()">Table of Contents</button>
 

--- a/_boostsrlwiki/01-getting-started.md
+++ b/_boostsrlwiki/01-getting-started.md
@@ -153,17 +153,17 @@ First it finds childof(B,A):
 
 _"fathers are parents"_
 
-![first learned tree, showing that fathers have children](https://github.com/boost-starai/BoostSRL-Misc/blob/master/Images/WILLTreeFor_fatherOf1.png "first learned tree, showing that fathers have children")
+<img src="https://raw.githubusercontent.com/boost-starai/BoostSRL-Misc/master/Images/WILLTreeFor_fatherOf1.png" style="display: block; margin: auto; padding-top: 0.4em; padding-bottom: 0.4em;">
 
 Next, if the person is male, they are also more likely to be a father:
 
 _"fathers are male"_
 
-![tenth learned tree, we've built on the error of the previous models, so now we show that fathers are probably male](https://github.com/boost-starai/BoostSRL-Misc/blob/master/Images/WILLTreeFor_fatherOf9.png "tenth learned tree, we've built on the error of the previous models, so now we show that fathers are probably male")
+<img src="https://raw.githubusercontent.com/boost-starai/BoostSRL-Misc/master/Images/WILLTreeFor_fatherOf9.png" style="display: block; margin: auto; padding-top: 0.4em; padding-bottom: 0.4em;">
 
 Each tree builds on the error of the previous tree. By combining the trees the model learned, we can see the decision the model finds most accurate.
 
-![trees one through ten, combined](https://github.com/boost-starai/BoostSRL-Misc/blob/master/Images/CombinedTreesfatherOf.png "trees one through ten, combined")
+<img src="https://raw.githubusercontent.com/boost-starai/BoostSRL-Misc/master/Images/CombinedTreesfatherOf.png" style="display: block; margin: auto; padding-top: 0.4em; padding-bottom: 0.4em;">
 
 This tree shows that a male father _E_ is the parent of child _D_. Alternatively, the person is also the father to his child's siblings.
 

--- a/_boostsrlwiki/02-file-structure.md
+++ b/_boostsrlwiki/02-file-structure.md
@@ -41,7 +41,7 @@ Think from a classic machine learning perspective. We divide data into training 
 
 If you want to use the model to perform inference on data you do not know the labels for, add your data to either `test_pos.txt` or `test_neg.txt`. The regression values in the `results_(target).txt` can be roughly interpreted as "What is the probability of this example being true/false?", respectfully.
 
-<button class=".btn .btn--primary .btn--large" onclick=topOfPage()">Table of Contents</button>
+<button class="btn btn--primary btn--large" onclick="topOfPage()">Table of Contents</button>
 
 ---
 

--- a/_boostsrlwiki/03-basic-parameters.md
+++ b/_boostsrlwiki/03-basic-parameters.md
@@ -64,6 +64,6 @@ From the [CiteSeer Dataset](CiteSeer-Dataset):
 
 <script>
 function topOfPage() {
-    $('html, body').animate({ scroll: 0 }, 'fast');
+    $('html, body').animate({ scrollTop: 0 }, 'fast');
 }
 </script>

--- a/_boostsrlwiki/05-basic-modes.md
+++ b/_boostsrlwiki/05-basic-modes.md
@@ -31,16 +31,11 @@ mode: shape(+car, #shape).
 mode: has_car(+train, -car).
 ```
 
-1. `+v`
-
-  indicates that variable `v` must have already been mentioned in the current rule. For instance, let us assume that the goal is to learn if the train is eastbound (i.e., `eastbound(train)` is the target)). The search algorithm first considers only the predicates that has a modeType `+train` in them. If no predicates has the modeType `+train`, the algorithm terminates. In this case, it will add `has_car` as it has the modeType `+train`.
-
-2. `-v`
-
+1. `+v`  
+  indicates that variable `v` must have already been mentioned in the current rule. For instance, let us assume that the goal is to learn if the train is eastbound (i.e., `eastbound(train)` is the target)). The search algorithm first considers only the predicates that has a modeType `+train` in them. If no predicates has the modeType `+train`, the algorithm terminates. In this case, it will add `has_car` as it has the modeType `+train`.  
+2. `-v`  
   indicates that a new variable `v` can be introduced into the clause (essentially an *existential*). Continuing the above example, `has_car` can be added because it has both `+train` and `-car`. `-car` allows for a new variable to be added and `+train` will allow for the algorithm to consider this predicate. It should be mentioned that if the mode definition had been `has_car(+train,+car)`, it would be ignored by the search. Though `train` has been declared earlier (in the target), `car` was not defined earlier and this predicate will be ignored. Therefore, to add a clause `has_car(X,Y) -> eastbound(X)` it is essential that the car is of type `-`.
-
-3. `#v`
-
+3. `#v`  
   indicates that `v` is of type constant. This is the simplest of all the modes since the variables are grounded and their specific values are searched over.
 
 Finally, if one observes closely, `has_car(X,Y) -> eastbound(X)` is not informative in that all the trains will have at least one car. Hence, the algorithm can never learn this clause. To enable learning of this clause, one has to increase the lookahead of the search algorithm. This can be achieved in two ways:
@@ -93,6 +88,6 @@ mode: father(+name,+name).
 
 <script>
 function topOfPage() {
-    $('html, body').animate({ scroll: 0 }, 'fast');
+    $('html, body').animate({ scrollTop: 0 }, 'fast');
 }
 </script>

--- a/_boostsrlwiki/09-regression.md
+++ b/_boostsrlwiki/09-regression.md
@@ -13,7 +13,7 @@ The type of regression implemented here is "**Least Square Error Tree Boosting**
 
 Loss function: `L(y,F(x)) = (y - F(x))^2`
 
-![least square error function, showing the result of the functional derivation of phi minus phi hat with respect to phi](https://github.com/boost-starai/BoostSRL-Misc/blob/master/Images/LSBoostRegression.png "least square error function, showing the result of the functional derivation of phi minus phi hat with respect to phi")
+<img src="https://raw.githubusercontent.com/boost-starai/BoostSRL-Misc/master/Images/LSBoostRegression.png" style="display: block; margin: auto; padding-top: 0.4em; padding-bottom: 0.4em;"/>
 
 <button class="btn btn--primary btn--large" onclick="topOfPage()">Table of Contents</button>
 
@@ -85,6 +85,6 @@ regressionExample(medv(id153),15.3).
 
 <script>
 function topOfPage() {
-    $('html, body').animate({ scroll: 0 }, 'fast');
+    $('html, body').animate({ scrollTop: 0 }, 'fast');
 }
 </script>

--- a/_boostsrlwiki/10-cost-sensitive-srl.md
+++ b/_boostsrlwiki/10-cost-sensitive-srl.md
@@ -32,3 +32,11 @@ CSSRL allows you to incorporate the domain knowledge on different weights of pos
 2. `-alpha` should be set to assign the weight on false negative examples.
 
 3. `-beta` should be set to assign the weight on false positive examples.
+
+<button class="btn btn--primary btn--large" onclick="topOfPage()">Table of Contents</button>
+
+<script>
+function topOfPage() {
+    $('html, body').animate({ scrollTop: 0 }, 'fast');
+}
+</script>

--- a/_boostsrlwiki/11-advice.md
+++ b/_boostsrlwiki/11-advice.md
@@ -91,9 +91,11 @@ Here is a basic dataset to help with understanding advice and its associated fil
 
 Download: [Toy-Advice.zip](https://github.com/boost-starai/BoostSRL-Misc/blob/master/Datasets/Toy-Advice/Toy-Advice.zip?raw=true) (27.5 KB)
 
-* `md5sum`: 7ad05a6cfa3b9cde55a96669cb94ed15
+* `md5sum`: 
+  <p style="word-break: break-all;">7ad05a6cfa3b9cde55a96669cb94ed15</p>
 
-* `sha256sum`: df60f5399a41ff8ef38f136366a55e4886d0af8705bfce55b761710a1f3848c7
+* `sha256sum`: 
+  <p style="word-break: break-all;">df60f5399a41ff8ef38f136366a55e4886d0af8705bfce55b761710a1f3848c7</p>
 
 advice.txt:
 ```
@@ -130,6 +132,6 @@ Test with:
 
 <script>
 function topOfPage() {
-    $('html, body').animate({ scroll: 0 }, 'fast');
+    $('html, body').animate({ scrollTop: 0 }, 'fast');
 }
 </script>

--- a/_boostsrlwiki/12-approximate-counting.md
+++ b/_boostsrlwiki/12-approximate-counting.md
@@ -58,6 +58,6 @@ There are certain limitations to using the approximate counting module (as discu
 
 <script>
 function topOfPage() {
-    $('html, body').animate({ scroll: 0 }, 'fast');
+    $('html, body').animate({ scrollTop: 0 }, 'fast');
 }
 </script>

--- a/_boostsrlwiki/13-discretization.md
+++ b/_boostsrlwiki/13-discretization.md
@@ -21,3 +21,11 @@ a1c(+Patient,+a1cValue).
 
 We want to discretize the 1rst argument and into 4 bins.
 disc: a1c([2],[4]).
+
+<button class="btn btn--primary btn--large" onclick="topOfPage()">Table of Contents</button>
+
+<script>
+function topOfPage() {
+    $('html, body').animate({ scrollTop: 0 }, 'fast');
+}
+</script>

--- a/_boostsrlwiki/14-lifted-relational-random-walks.md
+++ b/_boostsrlwiki/14-lifted-relational-random-walks.md
@@ -80,6 +80,6 @@ The output will be stored in 'RWRPredicates.txt' file in the same folder as inpu
 
 <script>
 function topOfPage() {
-    $('html, body').animate({ scroll: 0 }, 'fast');
+    $('html, body').animate({ scrollTop: 0 }, 'fast');
 }
 </script>

--- a/_boostsrlwiki/15-grounded-relational-random-walks.md
+++ b/_boostsrlwiki/15-grounded-relational-random-walks.md
@@ -19,7 +19,7 @@ This idea is now extended to grounded random walks from the given lifted random 
 
 Suppose we are provided with a lifted random walk as follows:
 
-![PersonID1 -> SamePerson -> PersonID -> IsA -> Designation -> not(isA) -> PersonID -> tempAdvisedBy -> PersonID2](https://raw.githubusercontent.com/boost-starai/BoostSRL-Misc/master/Images/liftedrandomwalkExample.png)
+<img src="https://raw.githubusercontent.com/boost-starai/BoostSRL-Misc/master/Images/liftedrandomwalkExample.png" style="display: block; margin: auto; padding-bottom: 0.4em; padding-top: 0.4em;"/>
 
 We are inferring the target relation `advisedBy(personid1,personid2)` by converting it into a clausal form that is acceptable to MLN-Boost inference.
 
@@ -88,6 +88,6 @@ The output grounded random walks are stored inside `./test/OutputRW.txt` Kindly 
 
 <script>
 function topOfPage() {
-    $('html, body').animate({ scroll: 0 }, 'fast');
+    $('html, body').animate({ scrollTop: 0 }, 'fast');
 }
 </script>

--- a/_boostsrlwiki/16-natural-language-processing.md
+++ b/_boostsrlwiki/16-natural-language-processing.md
@@ -31,6 +31,6 @@ Natural language processing is generally a hard task for methods which ignore th
 
 <script>
 function topOfPage() {
-    $('html, body').animate({ scroll: 0 }, 'fast');
+    $('html, body').animate({ scrollTop: 0 }, 'fast');
 }
 </script>

--- a/_datasets/01-toy-father.md
+++ b/_datasets/01-toy-father.md
@@ -65,9 +65,11 @@ The facts contain labels for `male`, `siblingof`, and `childof`.
 
 Download: [Toy-Father.zip](https://github.com/boost-starai/BoostSRL-Misc/blob/master/Datasets/Toy-Father/Toy-Father.zip?raw=true) (4.3 KB)
 
-* `md5sum`: a637cae7ba78997a0d0bb372d1edaf5e
+* `md5sum`: 
+  <p style="word-break: break-all;">a637cae7ba78997a0d0bb372d1edaf5e</p>
 
-* `sha256sum`: 75a45707975977daa7358e4678dd3eaf97293c6d98910e474c133593adb1cfd7
+* `sha256sum`: 
+  <p style="word-break: break-all;">75a45707975977daa7358e4678dd3eaf97293c6d98910e474c133593adb1cfd7</p>
 
 ---
 

--- a/_datasets/02-toy-cancer.md
+++ b/_datasets/02-toy-cancer.md
@@ -55,9 +55,11 @@ cancer(Earl).
 
 Download: [Toy-Cancer.zip](https://github.com/boost-starai/BoostSRL-Misc/blob/master/Datasets/Toy-Cancer/Toy-Cancer.zip?raw=true) (2.83 KB)
 
-* `md5sum`: fa15b64583f9b1abc7fd78b93025792d
+* `md5sum`: 
+  <p style="word-break: break-all;">fa15b64583f9b1abc7fd78b93025792d</p>
 
-* `sha256sum`: 618d9283caa5459711b01d7b535aa1e91c8c98945ed4085248368a373ce880c2
+* `sha256sum`: 
+  <p style="word-break: break-all;">618d9283caa5459711b01d7b535aa1e91c8c98945ed4085248368a373ce880c2</p>
 
 ---
 

--- a/_datasets/03-imdb.md
+++ b/_datasets/03-imdb.md
@@ -19,9 +19,11 @@ Target:
 
 Download: [IMDB.zip](https://github.com/boost-starai/BoostSRL-Misc/blob/master/Datasets/IMDB/IMDB.zip?raw=true) (29.6 KB)
 
-* `md5sum`: 70f85ae348531b3103008d4e6acfa379
+* `md5sum`: 
+  <p style="word-break: break-all;">70f85ae348531b3103008d4e6acfa379</p>
 
-* `sha256sum`: fe636348146f9f0ef0c2a081515abf543e3db9bdab1b441575955095c41e4c4f
+* `sha256sum`: 
+  <p style="word-break: break-all;">fe636348146f9f0ef0c2a081515abf543e3db9bdab1b441575955095c41e4c4f</p>
 
 [Table of Contents](#table-of-contents) - [BoostSRL Wiki](Home)
 

--- a/_datasets/04-cora.md
+++ b/_datasets/04-cora.md
@@ -24,9 +24,11 @@ The facts contain information on six labels: `author`, `haswordauthor`, `hasword
 
 Download: [Cora.zip](https://github.com/boost-starai/BoostSRL-Misc/blob/master/Datasets/Cora/Cora.zip?raw=true) (489 KB)
 
-* `md5sum`: 905ad622d003da817c00f9835f36dc2f
+* `md5sum`: 
+  <p style="word-break: break-all;">905ad622d003da817c00f9835f36dc2f</p>
 
-* `sha256sum`: 0a8b1f138d6827344c840bc3e3cccbe1eb40f2c102f929a05f4bc8f96ebbdae7
+* `sha256sum`: 
+  <p style="word-break: break-all;">0a8b1f138d6827344c840bc3e3cccbe1eb40f2c102f929a05f4bc8f96ebbdae7</p>
 
 ---
 

--- a/_datasets/05-uwcse.md
+++ b/_datasets/05-uwcse.md
@@ -23,9 +23,11 @@ The facts contain information on fourteen labels: `courselevel`, `hasposition`, 
 
 Download: [UW-CSE.zip](https://github.com/boost-starai/BoostSRL-Misc/blob/master/Datasets/UW-CSE/UW-CSE.zip?raw=true) (257 KB)
 
-* `md5sum`: 5e8217ebdb835ff8b6ff94eb3880d96b
+* `md5sum`: 
+  <p style="word-break: break-all;">5e8217ebdb835ff8b6ff94eb3880d96b</p>
 
-* `sha256sum`: f16be492805bdac95cded02a3a3e590c29a68145f5ea59eb4180c300fb23b7e2
+* `sha256sum`: 
+  <p style="word-break: break-all;">f16be492805bdac95cded02a3a3e590c29a68145f5ea59eb4180c300fb23b7e2</p>
 
 ---
 

--- a/_datasets/06-webkb.md
+++ b/_datasets/06-webkb.md
@@ -21,9 +21,11 @@ The facts contain information on five labels: `courseprof`, `courseta`, `project
 
 Download: [WebKB.zip](https://github.com/boost-starai/BoostSRL-Misc/blob/master/Datasets/WebKB/WebKB.zip?raw=true) (41.1 KB)
 
-* `md5sum`: 977e62fca51bfa7fe9c27bdf8af5d478
+* `md5sum`: 
+  <p style="word-break: break-all;">977e62fca51bfa7fe9c27bdf8af5d478</p>
 
-* `sha256sum`: 7b36e85cc99483a98c68fc868ba9890398339eaca20b48b80e4b56d16ddc1522
+* `sha256sum`: 
+  <p style="word-break: break-all;">7b36e85cc99483a98c68fc868ba9890398339eaca20b48b80e4b56d16ddc1522</p>
 
 ---
 

--- a/_datasets/07-citeseer.md
+++ b/_datasets/07-citeseer.md
@@ -21,9 +21,11 @@ Three targets are possible:
 
 Download: [CiteSeer.zip](https://github.com/boost-starai/BoostSRL-Misc/blob/master/Datasets/CiteSeer/CiteSeer.zip?raw=true) (1.62 MB)
 
-* `md5sum`: e606e6f3fbe12f62cb5261285b39209c
+* `md5sum`: 
+  <p style="word-break: break-all;">e606e6f3fbe12f62cb5261285b39209c</p>
 
-* `sha256sum`: f5f6dd960a09d98e80cb2dcb735463dbc7dc5aaf2676f98d938be7df6edd2200
+* `sha256sum`: 
+  <p style="word-break: break-all;">f5f6dd960a09d98e80cb2dcb735463dbc7dc5aaf2676f98d938be7df6edd2200</p>
 
 ---
 

--- a/_datasets/08-boston-housing.md
+++ b/_datasets/08-boston-housing.md
@@ -34,9 +34,11 @@ Features:
 
 Download: [Boston-Housing.zip](https://github.com/boost-starai/BoostSRL-Misc/blob/master/Datasets/Boston-Housing/Boston-Housing.zip?raw=true) (19 KB)
 
-* `md5sum`: 735bf2c6f0eb220950846a89cb973545
+* `md5sum`: 
+  <p style="word-break: break-all;">735bf2c6f0eb220950846a89cb973545</p>
 
-* `sha256sum`: 5ed2fa475cfa45d5e0327cdc6ff60f98a9621ff68f1fa4118ecfc20fc507754e
+* `sha256sum`: 
+  <p style="word-break: break-all;">5ed2fa475cfa45d5e0327cdc6ff60f98a9621ff68f1fa4118ecfc20fc507754e</p>
 
 ---
 


### PR DESCRIPTION
* [X] Summary of changes

* Added a `<p style="word-break: break-all;">` to resolve a style problem Harsha noticed on dataset pages. The lack of word break caused the file hashes to overflow the page and create horizontal scroll bars on mobile and smaller screens.
* Switching out how GitHub Markdown-style image loading with html `img src` loading, while also centering images on each page.
* Scripts at the bottom of wiki pages had a typo (`scroll`, rather than the proper `scrollTop`) which prevented the  table of content buttons from working properly.